### PR TITLE
Update features path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ CNN_randRNN
 ├── src
 ├── logs
 </pre>
+If the dataset directory is read-only you can pass an absolute path to `--features-root`
+to store models and features elsewhere.
 
 ### Washington RGB-D Object Recognition
 #### Data Preparation

--- a/more_info.md
+++ b/more_info.md
@@ -6,9 +6,11 @@ The command line parameters with their default values for running the program:<b
 This is the root path of the dataset. <br/>
 
 ```
- --features-root "models-features" 
+ --features-root "models-features"
 ```
-This is the root folder for saving/loading models, features, weights, etc.<br/>
+This is the root folder for saving/loading models, features, weights, etc. The
+path can also be an absolute directory (e.g. `/kaggle/working/features`) to store
+outputs outside the dataset location.<br/>
 
 ```
 --data-type "crop" 

--- a/src/base_model.py
+++ b/src/base_model.py
@@ -312,7 +312,7 @@ class Model:
     @basic_utils.profile
     def reduction_random_weights(self):
         if self.params.reuse_randoms:
-            save_load_dir = self.params.dataset_path + self.params.features_root + 'random_weights/'
+            save_load_dir = self.params.features_root + 'random_weights/'
             reduc_weights_file = save_load_dir + self.params.net_model + '_reduction_random_weights.pkl'
             if not os.path.exists(save_load_dir):
                 os.makedirs(save_load_dir)
@@ -346,7 +346,7 @@ class Model:
     @basic_utils.profile
     def rnn_random_weights(self):
         if self.params.reuse_randoms:
-            save_load_dir = self.params.dataset_path + self.params.features_root + 'random_weights/'
+            save_load_dir = self.params.features_root + 'random_weights/'
             rnn_weights_file = save_load_dir + self.params.net_model + '_rnn_random_weights.pkl'
             if not os.path.exists(save_load_dir):
                 os.makedirs(save_load_dir)
@@ -387,7 +387,7 @@ class Model:
 
     def save_recursive_features(self, filenames, batch_ind, phase):
 
-        save_dir = self.params.dataset_path + self.params.features_root + self.params.proceed_step + '/' + \
+        save_dir = self.params.features_root + self.params.proceed_step + '/' + \
                    self.params.net_model + '_results_' + self.params.data_type
 
         if self.params.proceed_step == RunSteps.FINE_RECURSIVE_NN:
@@ -427,7 +427,7 @@ class Model:
 
     def save_svm_conf_scores(self, l1_conf_scores, l2_conf_scores, l3_conf_scores, l4_conf_scores, l5_conf_scores,
                              l6_conf_scores, l7_conf_scores):
-        save_load_dir = self.params.dataset_path + self.params.features_root + self.params.proceed_step + \
+        save_load_dir = self.params.features_root + self.params.proceed_step + \
                         '/svm_confidence_scores/'
         confidence_scores_file = save_load_dir + self.params.net_model + '_' + self.params.data_type + '_split_' + \
                                  str(self.params.split_no) + '.hdf5'
@@ -479,7 +479,7 @@ class Model:
     def confidence_fusion(self):
         l1, l2, l3 = self.get_best_trio_layers()
 
-        save_load_dir = self.params.dataset_path + self.params.features_root + self.params.proceed_step + \
+        save_load_dir = self.params.features_root + self.params.proceed_step + \
                         '/svm_confidence_scores/'
         confidence_scores_file = save_load_dir + self.params.net_model + '_' + self.params.data_type + '_split_' + \
                                  str(self.params.split_no) + '.hdf5'
@@ -578,7 +578,7 @@ class Model:
             _, depth_best = self.get_best_modality_layers()
 
         self.params.data_type = DataTypes.RGBD
-        save_load_dir = self.params.dataset_path + self.params.features_root + self.params.proceed_step + \
+        save_load_dir = self.params.features_root + self.params.proceed_step + \
                         '/svm_confidence_scores/'
         rgb_confidence_scores_file = save_load_dir + self.params.net_model + '_' + DataTypes.RGB + '_split_' + \
                                      str(self.params.split_no) + '.hdf5'

--- a/src/demo_scene/demo.py
+++ b/src/demo_scene/demo.py
@@ -234,7 +234,7 @@ def run_demo(params):
     device = torch.device("cuda")
     model_rnn = ResNetScene(params)
 
-    save_load_dir = params.dataset_path + params.features_root + params.proceed_step + '/svm_estimators/'
+    save_load_dir = params.features_root + params.proceed_step + '/svm_estimators/'
     svm_estimators_file = save_load_dir + params.net_model + '_' + params.data_type
 
     l5_svm_estimator_file = svm_estimators_file + '_l5.sav'
@@ -245,9 +245,9 @@ def run_demo(params):
     l6_svm_estimator = joblib.load(l6_svm_estimator_file)
     l7_svm_estimator = joblib.load(l7_svm_estimator_file)
 
-    test_img_dir = params.dataset_path + params.features_root + params.proceed_step + '/demo_images/'
+    test_img_dir = params.features_root + params.proceed_step + '/demo_images/'
 
-    save_dir = params.dataset_path + params.features_root + RunSteps.FINE_TUNING + '/'
+    save_dir = params.features_root + RunSteps.FINE_TUNING + '/'
     best_model_file = save_dir + params.net_model + '_' + params.data_type + '_best_checkpoint.pth'
 
     num_classes = len(sunrgbd.class_names)

--- a/src/extract_cnn_features.py
+++ b/src/extract_cnn_features.py
@@ -70,7 +70,7 @@ def finetuned_extraction(params):
     device = torch.device("cuda")
     logging.info('Using device "{}"'.format(device))
 
-    save_dir = params.dataset_path + params.features_root + RunSteps.FINE_TUNING + '/'
+    save_dir = params.features_root + RunSteps.FINE_TUNING + '/'
     best_model_file = save_dir + params.net_model + '_' + params.data_type + '_split_' + str(params.split_no) + \
                       '_best_checkpoint.pth'
 

--- a/src/finetune_models.py
+++ b/src/finetune_models.py
@@ -99,7 +99,7 @@ def train_model(model, data_loaders, criterion, optimizer, scheduler, device, nu
 def process_finetuning(params):
     num_classes = len(wrgbd51.class_names)
     # uncomment saving codes after param search
-    save_dir = params.dataset_path + params.features_root + RunSteps.FINE_TUNING + '/'
+    save_dir = params.features_root + RunSteps.FINE_TUNING + '/'
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
     best_model_file = save_dir + params.net_model + '_' + params.data_type + '_split_' + str(params.split_no) + \

--- a/src/main.py
+++ b/src/main.py
@@ -9,8 +9,7 @@ from overall_struct import run_overall_steps
 
 def is_suitable_rgbd_fusion(params):
     if params.proceed_step in (RunSteps.FIX_RECURSIVE_NN, RunSteps.FINE_RECURSIVE_NN, RunSteps.OVERALL_RUN):
-        confidence_scores_path = params.dataset_path + params.features_root + params.proceed_step + \
-                                 '/svm_confidence_scores/'
+        confidence_scores_path = params.features_root + params.proceed_step + '/svm_confidence_scores/'
         if not os.path.exists(confidence_scores_path):
             print('{}{}Failed to load the RGB/Depth scores! First, you need to run the system to create RGB/Depth '
                   'scores!{}'.format(PrForm.BOLD, PrForm.RED, PrForm.END_FORMAT))
@@ -99,7 +98,11 @@ def init_save_dirs(params):
     annex = ''
     if params.debug_mode:
         annex += '[debug]'
-    params.features_root += annex + '/'
+
+    if not os.path.isabs(params.features_root):
+        params.features_root = os.path.join(params.dataset_path, params.features_root)
+
+    params.features_root = os.path.abspath(params.features_root) + annex + '/'
     params.log_dir += annex + '/'
 
     return params

--- a/src/main_steps.py
+++ b/src/main_steps.py
@@ -22,8 +22,7 @@ def is_suitable_level_fusion(params):
         else:
             is_suitable = False
     else:
-        confidence_scores_path = params.dataset_path + params.features_root + params.proceed_step + \
-                                 '/svm_confidence_scores/'
+        confidence_scores_path = params.features_root + params.proceed_step + '/svm_confidence_scores/'
         if not os.path.exists(confidence_scores_path):
             print('{}{}Failed to load the RGB/Depth scores! First, you need to run the system to create RGB/Depth '
                   'scores!{}'.format(PrForm.BOLD, PrForm.RED, PrForm.END_FORMAT))
@@ -37,15 +36,15 @@ def is_suitable_level_fusion(params):
 
 def is_cnn_rnn_features_available(params, cnn):
     if params.proceed_step == RunSteps.FIX_RECURSIVE_NN:
-        cnn_feats_path = params.dataset_path + params.features_root + RunSteps.FIX_EXTRACTION + '/' + \
+        cnn_feats_path = params.features_root + RunSteps.FIX_EXTRACTION + '/' + \
                          params.net_model + '_results_' + params.data_type
-        rnn_feats_path = params.dataset_path + params.features_root + params.proceed_step + '/' + \
+        rnn_feats_path = params.features_root + params.proceed_step + '/' + \
                          params.net_model + '_results_' + params.data_type
     elif params.proceed_step == RunSteps.FINE_RECURSIVE_NN:
-        cnn_feats_path = params.dataset_path + params.features_root + RunSteps.FINE_TUNING + \
+        cnn_feats_path = params.features_root + RunSteps.FINE_TUNING + \
                          '/split-' + str(params.split_no) + '/' + params.net_model + '_results_' + \
                          params.data_type
-        rnn_feats_path = params.dataset_path + params.features_root + params.proceed_step + '/' + \
+        rnn_feats_path = params.features_root + params.proceed_step + '/' + \
                          params.net_model + '_results_' + params.data_type + '/split_' + str(params.split_no)
     else:
         return True

--- a/src/overall_struct.py
+++ b/src/overall_struct.py
@@ -113,7 +113,7 @@ def run_overall_steps(params):
 
     else:
         if params.run_mode == OverallModes.FINETUNE_MODEL:
-            save_dir = params.dataset_path + params.features_root + RunSteps.FINE_TUNING + '/'
+            save_dir = params.features_root + RunSteps.FINE_TUNING + '/'
             best_model_file = save_dir + params.net_model + '_' + params.data_type + '_split_' + \
                               str(params.split_no) + '_best_checkpoint.pth'
 

--- a/src/save_colored_depth.py
+++ b/src/save_colored_depth.py
@@ -12,7 +12,7 @@ from depth_utils import colorized_surfnorm
 def process_depth_save(params):
     suffix = '*_' + params.data_type + '.png'
     data_path = os.path.join(params.dataset_path, 'eval-set/')
-    results_dir = params.dataset_path + params.features_root + params.proceed_step + '/' + \
+    results_dir = params.features_root + params.proceed_step + '/' + \
                   params.net_model + '_results_' + params.data_type
     if not os.path.exists(results_dir):
         os.makedirs(results_dir)

--- a/src/utils/loader_utils.py
+++ b/src/utils/loader_utils.py
@@ -20,7 +20,7 @@ def cnn_or_rnn_features_loader(path):
 
 def custom_loader(path, params):
     if params.data_type == DataTypes.Depth:
-        results_dir = params.dataset_path + params.features_root + RunSteps.COLORIZED_DEPTH_SAVE + '/' + \
+        results_dir = params.features_root + RunSteps.COLORIZED_DEPTH_SAVE + '/' + \
                       'all' + '_results_' + params.data_type
         if os.path.exists(results_dir):  # if colorized depth images are already saved read them
             img_path = results_dir + '/' + path.split('/')[-1] + '.hdf5'

--- a/src/utils/wrgbd_loader.py
+++ b/src/utils/wrgbd_loader.py
@@ -35,7 +35,7 @@ class WashingtonAll(Dataset):
     def _init_dataset(self):
         data = []
         data_path = os.path.join(self.params.dataset_path, 'eval-set/')
-        results_dir = self.params.dataset_path + self.params.features_root + self.params.proceed_step + '/' + \
+        results_dir = self.params.features_root + self.params.proceed_step + '/' + \
                       self.params.net_model + '_results_' + self.params.data_type
         if not os.path.exists(results_dir):
             os.makedirs(results_dir)
@@ -133,24 +133,24 @@ class WashingtonDataset(Dataset):
             if self.params.proceed_step == RunSteps.FIX_RECURSIVE_NN:
                 # this means rnn features are already saved or wanted to be load
                 if self.params.load_features:
-                    rnn_feats_path = self.params.dataset_path + self.params.features_root + self.params.proceed_step + \
+                    rnn_feats_path = self.params.features_root + self.params.proceed_step + \
                                      '/' + self.params.net_model + '_results_' + self.params.data_type
                     path = rnn_feats_path + '/' + file + '.hdf5'
                 else:
                     # the already extracted fixed CNN features are expected in the below path
-                    cnn_feats_path = self.params.dataset_path + self.params.features_root + RunSteps.FIX_EXTRACTION + \
+                    cnn_feats_path = self.params.features_root + RunSteps.FIX_EXTRACTION + \
                                      '/' + self.params.net_model + '_results_' + self.params.data_type
                     path = cnn_feats_path + '/' + file + '.hdf5'
             elif self.params.proceed_step == RunSteps.FINE_RECURSIVE_NN:
                 # this means rnn features are already saved or wanted to be load
                 if self.params.load_features:
-                    rnn_feats_path = self.params.dataset_path + self.params.features_root + self.params.proceed_step + \
+                    rnn_feats_path = self.params.features_root + self.params.proceed_step + \
                                      '/' + self.params.net_model + '_results_' + self.params.data_type + \
                                      '/split_' + str(self.params.split_no)
                     path = rnn_feats_path + '/' + file + '.hdf5'
                 else:
                     # the already extracted finetuned CNN features are expected in the below path
-                    cnn_feats_path = self.params.dataset_path + self.params.features_root + RunSteps.FINE_TUNING + \
+                    cnn_feats_path = self.params.features_root + RunSteps.FINE_TUNING + \
                                      '/split-' + str(self.params.split_no) + '/' + self.params.net_model + \
                                      '_results_' + self.params.data_type
                     path = cnn_feats_path + '/' + file + '.hdf5'


### PR DESCRIPTION
## Summary
- allow `--features-root` to be absolute and join with dataset path only when needed
- drop dataset path concatenation to features path across modules
- document absolute features path support

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bc3c07000832b9d467cd6095b0a3f