### PR TITLE
Fix path for SVM confidence scores

### DIFF
--- a/src/overall_struct.py
+++ b/src/overall_struct.py
@@ -72,12 +72,13 @@ def process_classification_stage(model_rnn, run_mode):
     l7_conf_scores = model_rnn.eval_layer7()
     logging.info('----------\n')
 
-    model_rnn.save_svm_conf_scores(l1_conf_scores, l2_conf_scores, l3_conf_scores, l4_conf_scores, l5_conf_scores,
-                                   l6_conf_scores, l7_conf_scores)
     if run_mode == OverallModes.FIX_PRETRAIN_MODEL:
         model_rnn.params.proceed_step = RunSteps.FIX_RECURSIVE_NN
     else:
         model_rnn.params.proceed_step = RunSteps.FINE_RECURSIVE_NN
+
+    model_rnn.save_svm_conf_scores(l1_conf_scores, l2_conf_scores, l3_conf_scores, l4_conf_scores, l5_conf_scores,
+                                   l6_conf_scores, l7_conf_scores)
 
     model_rnn.fusion_layers()
     logging.info('----------\n')


### PR DESCRIPTION
## Summary
- ensure `process_classification_stage` sets `proceed_step` according to run mode before saving SVM confidence scores
- keep fusion stage and reset `proceed_step`

## Testing
- `python -m py_compile src/overall_struct.py`

------
https://chatgpt.com/codex/tasks/task_e_688cd00e482c832bbb03004244872fa3