### PR TITLE
Fix proceed_step update before saving classification scores

### DIFF
--- a/src/overall_struct.py
+++ b/src/overall_struct.py
@@ -77,12 +77,13 @@ def process_classification_stage(model_rnn, run_mode):
     else:
         model_rnn.params.proceed_step = RunSteps.FINE_RECURSIVE_NN
 
+    # switch to OVERALL_RUN for saving the scores and fusion
+    model_rnn.params.proceed_step = RunSteps.OVERALL_RUN
     model_rnn.save_svm_conf_scores(l1_conf_scores, l2_conf_scores, l3_conf_scores, l4_conf_scores, l5_conf_scores,
                                    l6_conf_scores, l7_conf_scores)
 
     model_rnn.fusion_layers()
     logging.info('----------\n')
-    model_rnn.params.proceed_step = RunSteps.OVERALL_RUN
 
 
 def process_fusion(model_rnn, params):


### PR DESCRIPTION
## Summary
- set `proceed_step` to `RunSteps.OVERALL_RUN` before saving SVM confidence scores
- ensure `fusion_layers()` uses the same directory for loading the scores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdf73cd00832b94d3eb36b927b6ea