### PR TITLE
Fix docs typos and logparser comparisons

### DIFF
--- a/more_info.md
+++ b/more_info.md
@@ -75,7 +75,7 @@ Pooling method can be one of `max`, `avg`, and `random`.<br/>
 ```
 --load-features 0  
 ```
-If the features are already saved (with the `--save-fatures 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
+If the features are already saved (with the `--save-features 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
 
 There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way. 
 

--- a/src/logparser/logparser.py
+++ b/src/logparser/logparser.py
@@ -57,11 +57,11 @@ def read_file(params, log_file):
         line = fp.readline()
         while line:
             if 'Running Layer-' in line:
-                if params.mode is 'accuracy':
+                if params.mode == 'accuracy':
                     accuracy = get_accuracy(fp)
                     accuracies.append(accuracy)
             elif ('before' and 'after') in line:
-                if params.mode is not 'accuracy':
+                if params.mode != 'accuracy':
                     memory_con, exec_time = get_memory_time(line)
                     mem_cons.append(memory_con)
                     exec_times.append(exec_time)
@@ -69,7 +69,7 @@ def read_file(params, log_file):
             line = fp.readline()
 
     fp.close()
-    if params.mode is 'accuracy':
+    if params.mode == 'accuracy':
         return accuracies
     else:
         return mem_cons, exec_times
@@ -138,11 +138,11 @@ def process_one_log(params):
                    params.net + '_' + params.data_type + '_split_' + str(params.split) + '.log'
     else:
         log_file = params.log_file
-    if params.mode is 'accuracy':
+    if params.mode == 'accuracy':
         accuracies = read_file(params, log_file)
         for acc in accuracies:
             print('{}'.format(acc))
-    elif params.mode is 'mem_time':
+    elif params.mode == 'mem_time':
         mem_cons, exec_times = read_file(params, log_file)
         for i in range(len(mem_cons)):
             print('{}\t{}'.format(mem_cons[i], exec_times[i]))
@@ -157,7 +157,7 @@ def process_logs_from_dir(params):
             sorted(os.listdir(path), key=lambda x: int(x.split(params.net_model)[0][-2])),
             key=lambda x: int(x.split('split_')[1].split('.log')[0])
     ), suffix):
-        if params.mode is 'avr_mem_time':
+        if params.mode == 'avr_mem_time':
             if params.split == int(logfile.split('split_')[1].split('.log')[0]):
                 mem_cons, exec_times = read_file(params, os.path.join(path, logfile))
                 list_mem_cons.append(mem_cons)
@@ -167,7 +167,7 @@ def process_logs_from_dir(params):
             print('Processing file {}'.format(logfile))
             process_one_log(params)
 
-    if params.mode is 'avr_mem_time':
+    if params.mode == 'avr_mem_time':
         print('average memory and time stats for {} split-{} {} images'.format(params.net_model, params.split, suffix))
         num_file = len(list_mem_cons)
         file_record_len = len(list_mem_cons[0])

--- a/sunrgbd_info.md
+++ b/sunrgbd_info.md
@@ -12,7 +12,7 @@ This copies RGB images into `train/test` folders by renaming files with category
 sh run_steps.sh step="SAVE_SUNRGBD"
 python main_steps.py --dataset-path "../data/sunrgbd/" --data-type "Depth_Colorized_HDF5" --debug-mode 0
 ```
-This converts depth maps to the proposed colorized RGB-like representations using the provided camera intrinsic values and saves files in `train/test` folders and `hdf5` file format. See the file structure <a href="https://github.com/acaglayan/CNN_randRNN/edit/master/README.md" target="_blank">here</a> for the saved files location.
+This converts depth maps to the proposed colorized RGB-like representations using the provided camera intrinsic values and saves files in `train/test` folders and `hdf5` file format. See the file structure <a href="https://github.com/acaglayan/CNN_randRNN/blob/master/README.md" target="_blank">here</a> for the saved files location.
 <br/>
 
 Note that, data preparation works quite slowly especially for the depth data. Nevertheless, it is needed to run just once. <br/>
@@ -96,7 +96,7 @@ Pooling method can be one of `max`, `avg`, and `random`.<br/>
 ```
 --load-features 0  
 ```
-If the features are already saved (with the `--save-fatures 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
+If the features are already saved (with the `--save-features 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
 
 There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way. 
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -49,3 +49,16 @@ def test_randomized_pool_values():
     out = model_utils.randomized_pool(weights, data, num_split=2)
     expected = np.array([[[[1 + 3]], [[2 + 4]]]], dtype=np.float32)
     assert np.allclose(out, expected)
+
+def test_flat_2d():
+    data = np.arange(16, dtype=np.float32).reshape(2, 2, 2, 2)
+    out = model_utils.flat_2d(data)
+    assert out.shape == (2, 8)
+    assert np.allclose(out[0], np.arange(8))
+
+def test_reshape_4d():
+    data = np.arange(16, dtype=np.float32).reshape(1, 16)
+    out = model_utils.reshape_4d(data, (4, 2, 2))
+    expected = data.reshape(1, 4, 2, 2)
+    assert out.shape == expected.shape
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- fix `--save-features` documentation typo
- repair README hyperlink in `sunrgbd_info.md`
- use `==`/`!=` for string comparisons in `logparser.py`
- extend pooling utilities tests

## Testing
- `pytest -q` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_688bc0020428832b88153a97b389cd66