### PR TITLE
Fix step assignment around SVM score saving

### DIFF
--- a/src/overall_struct.py
+++ b/src/overall_struct.py
@@ -77,12 +77,12 @@ def process_classification_stage(model_rnn, run_mode):
     else:
         model_rnn.params.proceed_step = RunSteps.FINE_RECURSIVE_NN
 
-    # switch to OVERALL_RUN for saving the scores and fusion
-    model_rnn.params.proceed_step = RunSteps.OVERALL_RUN
     model_rnn.save_svm_conf_scores(l1_conf_scores, l2_conf_scores, l3_conf_scores, l4_conf_scores, l5_conf_scores,
                                    l6_conf_scores, l7_conf_scores)
 
     model_rnn.fusion_layers()
+
+    model_rnn.params.proceed_step = RunSteps.OVERALL_RUN
     logging.info('----------\n')
 
 


### PR DESCRIPTION
## Summary
- set `proceed_step` before saving SVM confidence scores
- keep this value until after fusion to load the same file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cecc40664832ba7843536da77a913