### PR TITLE
Fix SVM default iterations

### DIFF
--- a/src/utils/basic_utils.py
+++ b/src/utils/basic_utils.py
@@ -14,8 +14,8 @@ def classify(train_data, train_labels, test_data):
     # dual : bool, (default=True)
     # Select the algorithm to either solve the dual or primal optimization problem.
     # Prefer dual=False when n_samples > n_features.
-    # max_iter=2000, loss='hinge'
-    clf = svm.LinearSVC()
+    # max_iter=5000, loss='hinge'
+    clf = svm.LinearSVC(max_iter=5000)
     clf.fit(train_data, train_labels)
 
     preds = clf.predict(test_data)


### PR DESCRIPTION
## Summary
- increase `LinearSVC` iterations to avoid convergence warnings
- update the comment describing the defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cedd9bb68832b9a178c89e0635634