### PR TITLE
Add SVM iteration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ To run the overall pipeline with the default parameter values:
 python main.py
 ```
 This will train/test SVM for every 7 layers. You may want to make levels other than that of optimum ones to the comment lines.
+The iteration limit of the underlying linear SVM can be tuned via the
+`--svm-max-iter` option (default is `5000`).
 It is also possible to run the system step by step. See the details <a href="https://github.com/acaglayan/CNN_randRNN/blob/master/more_info.md"> here</a>.
 
 ### SUN RGB-D Scene Recognition

--- a/more_info.md
+++ b/more_info.md
@@ -77,7 +77,9 @@ Pooling method can be one of `max`, `avg`, and `random`.<br/>
 ```
 If the features are already saved (with the `--save-features 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
 
-There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way. 
+There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way.
+
+Another parameter `--svm-max-iter` sets the maximum iteration count for the linear SVM classifier (default `5000`).
 
 
 #### Run Individual Steps

--- a/src/base_model.py
+++ b/src/base_model.py
@@ -151,7 +151,12 @@ class Model:
             layer_train = model_utils.flat_2d(layer_train)
             layer_test = model_utils.flat_2d(layer_test)
         logging.info('CNN feature dimension {}'.format(layer_train.shape[1]))
-        preds, confidence_scores = basic_utils.classify(layer_train, self.train_labels, layer_test)
+        preds, confidence_scores = basic_utils.classify(
+            layer_train,
+            self.train_labels,
+            layer_test,
+            max_iter=self.params.svm_max_iter,
+        )
 
         avg_res_cnn, true_preds_cnn, test_size_cnn = self.calc_scores(preds)
 
@@ -159,7 +164,12 @@ class Model:
 
     def classify_rnn_features(self, layer_train, layer_test):
         logging.info('RNN feature dimension {}'.format(layer_train.shape[1]))
-        preds, confidence_scores = basic_utils.classify(layer_train, self.train_labels, layer_test)
+        preds, confidence_scores = basic_utils.classify(
+            layer_train,
+            self.train_labels,
+            layer_test,
+            max_iter=self.params.svm_max_iter,
+        )
 
         avg_res_rnn, true_preds_rnn, test_size_rnn = self.calc_scores(preds)
 

--- a/src/main.py
+++ b/src/main.py
@@ -122,6 +122,8 @@ def get_overall_run_params():
                         type=str.lower, help="Pooling type")
     parser.add_argument("--load-features", dest="load_features", default=0, type=int, choices=[0])
     parser.add_argument("--trial", dest="trial", default=0, type=int, help="For multiple runs")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=5000, type=int,
+                        help="Maximum iterations for linear SVM")
     params = parser.parse_args()
     params.proceed_step = RunSteps.OVERALL_RUN
     return params

--- a/src/main_steps.py
+++ b/src/main_steps.py
@@ -202,6 +202,8 @@ def get_recursive_params(proceed_step):
     parser.add_argument("--load-features", dest="load_features", default=0, type=int, choices=[0, 1])
     parser.add_argument("--pooling", dest="pooling", default=Pools.RANDOM, choices=Pools.ALL,
                         type=str.lower, help="Pooling type")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=5000, type=int,
+                        help="Maximum iterations for linear SVM")
     params = parser.parse_args()
     params.proceed_step = proceed_step
     return params

--- a/src/utils/basic_utils.py
+++ b/src/utils/basic_utils.py
@@ -9,13 +9,26 @@ import torch
 from sklearn import svm
 
 
-def classify(train_data, train_labels, test_data):
+def classify(train_data, train_labels, test_data, max_iter=5000):
+    """Train a linear SVM and classify test data.
+
+    Parameters
+    ----------
+    train_data : array-like
+        Training features.
+    train_labels : array-like
+        Labels corresponding to ``train_data``.
+    test_data : array-like
+        Test features to classify.
+    max_iter : int, optional
+        Maximum number of iterations for ``LinearSVC`` solver.
+    """
+
     # LinearSVC parameters
     # dual : bool, (default=True)
     # Select the algorithm to either solve the dual or primal optimization problem.
     # Prefer dual=False when n_samples > n_features.
-    # max_iter=5000, loss='hinge'
-    clf = svm.LinearSVC(max_iter=5000)
+    clf = svm.LinearSVC(max_iter=max_iter)
     clf.fit(train_data, train_labels)
 
     preds = clf.predict(test_data)


### PR DESCRIPTION
## Summary
- expose `--svm-max-iter` option for main pipeline and recursive steps
- let `basic_utils.classify` accept a max_iter argument
- pass configured limit when training SVMs
- document the new parameter in README and more_info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0b646b08832bae0b0180ca46d1b1