### PR TITLE
Add SVM max_iter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ To run the overall pipeline with the default parameter values:
 python main.py
 ```
 This will train/test SVM for every 7 layers. You may want to make levels other than that of optimum ones to the comment lines.
+The number of iterations used by the underlying Linear SVM solver can be changed via
+the `--svm-max-iter` option (default `10000`).
 It is also possible to run the system step by step. See the details <a href="https://github.com/acaglayan/CNN_randRNN/blob/master/more_info.md"> here</a>.
 
 ### SUN RGB-D Scene Recognition

--- a/more_info.md
+++ b/more_info.md
@@ -77,7 +77,12 @@ Pooling method can be one of `max`, `avg`, and `random`.<br/>
 ```
 If the features are already saved (with the `--save-features 1`), it is possible to load them without the need for run the whole pipeline again by setting this parameter to `1`.<br/>
 
-There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way. 
+There is one other parameter `--trial`. This is a control param for multiple runs. It could be used for multiple runs to evaluate different parameters in a controlled way.
+
+``` 
+--svm-max-iter 10000
+```
+Controls the maximum number of iterations used by the Linear SVM solver.
 
 
 #### Run Individual Steps

--- a/src/base_model.py
+++ b/src/base_model.py
@@ -151,7 +151,9 @@ class Model:
             layer_train = model_utils.flat_2d(layer_train)
             layer_test = model_utils.flat_2d(layer_test)
         logging.info('CNN feature dimension {}'.format(layer_train.shape[1]))
-        preds, confidence_scores = basic_utils.classify(layer_train, self.train_labels, layer_test)
+        preds, confidence_scores = basic_utils.classify(
+            layer_train, self.train_labels, layer_test,
+            max_iter=self.params.svm_max_iter)
 
         avg_res_cnn, true_preds_cnn, test_size_cnn = self.calc_scores(preds)
 
@@ -159,7 +161,9 @@ class Model:
 
     def classify_rnn_features(self, layer_train, layer_test):
         logging.info('RNN feature dimension {}'.format(layer_train.shape[1]))
-        preds, confidence_scores = basic_utils.classify(layer_train, self.train_labels, layer_test)
+        preds, confidence_scores = basic_utils.classify(
+            layer_train, self.train_labels, layer_test,
+            max_iter=self.params.svm_max_iter)
 
         avg_res_rnn, true_preds_rnn, test_size_rnn = self.calc_scores(preds)
 

--- a/src/main.py
+++ b/src/main.py
@@ -122,6 +122,8 @@ def get_overall_run_params():
                         type=str.lower, help="Pooling type")
     parser.add_argument("--load-features", dest="load_features", default=0, type=int, choices=[0])
     parser.add_argument("--trial", dest="trial", default=0, type=int, help="For multiple runs")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.proceed_step = RunSteps.OVERALL_RUN
     return params

--- a/src/main_steps.py
+++ b/src/main_steps.py
@@ -171,6 +171,8 @@ def extract_finetuned_features():
 
 def get_save_depth_params():
     parser = get_initial_parser()
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.net_model = 'all'
     params.proceed_step = RunSteps.COLORIZED_DEPTH_SAVE
@@ -181,6 +183,8 @@ def get_save_depth_params():
 def get_extraction_params():
     parser = get_initial_parser()
     parser.add_argument("--batch-size", dest="batch_size", default=64, type=int)
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.proceed_step = RunSteps.FIX_EXTRACTION
     return params
@@ -202,6 +206,8 @@ def get_recursive_params(proceed_step):
     parser.add_argument("--load-features", dest="load_features", default=0, type=int, choices=[0, 1])
     parser.add_argument("--pooling", dest="pooling", default=Pools.RANDOM, choices=Pools.ALL,
                         type=str.lower, help="Pooling type")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.proceed_step = proceed_step
     return params
@@ -220,6 +226,8 @@ def get_finetune_params():
     parser.add_argument("--trial", dest="trial", default=0, type=int,
                         help="Trial number is used to run the same model with the same params to evaluate "
                              "the effect of randomness.")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.proceed_step = RunSteps.FINE_TUNING
     return params
@@ -229,6 +237,8 @@ def get_finetuned_extraction_params():
     parser = get_initial_parser()
     parser.add_argument("--batch-size", dest="batch_size", default=64, type=int)
     parser.add_argument("--split-no", dest="split_no", default=1, type=int, choices=range(1, 11), help="Split number")
+    parser.add_argument("--svm-max-iter", dest="svm_max_iter", default=10000, type=int,
+                        help="Max iterations for LinearSVC")
     params = parser.parse_args()
     params.proceed_step = RunSteps.FINE_EXTRACTION
     return params

--- a/src/utils/basic_utils.py
+++ b/src/utils/basic_utils.py
@@ -9,13 +9,13 @@ import torch
 from sklearn import svm
 
 
-def classify(train_data, train_labels, test_data):
+def classify(train_data, train_labels, test_data, max_iter=10000):
     # LinearSVC parameters
     # dual : bool, (default=True)
     # Select the algorithm to either solve the dual or primal optimization problem.
     # Prefer dual=False when n_samples > n_features.
     # max_iter=5000, loss='hinge'
-    clf = svm.LinearSVC(max_iter=10000)
+    clf = svm.LinearSVC(max_iter=max_iter)
     clf.fit(train_data, train_labels)
 
     preds = clf.predict(test_data)


### PR DESCRIPTION
## Summary
- allow specifying maximum iterations for LinearSVC
- pass the new parameter through CLI in all main entrypoints
- use new option when training SVM classifiers
- document the new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1917f8a0832bb5c9300060d849cc